### PR TITLE
exporter respects perforce enabled setting in tools_config.json

### DIFF
--- a/Freeform.Python/FreeformRigging/Maya/metadata/meta_properties.py
+++ b/Freeform.Python/FreeformRigging/Maya/metadata/meta_properties.py
@@ -1108,9 +1108,12 @@ class CharacterAnimationAsset(ExportAssetProperty):
         if not os.path.exists(export_directory):
             os.makedirs(export_directory)
 
+        config_manager = v1_core.global_settings.ConfigManager()
+        check_perforce = config_manager.get("Perforce").get("Enabled")
+
         freeform_utils.fbx_presets.FBXAnimation().load()
         pm.select(export_root, replace=True)
-        maya_utils.scene_utils.export_selected_safe(export_path, checkout = True, s = True)
+        maya_utils.scene_utils.export_selected_safe(export_path, checkout = check_perforce, s = True)
 
 
 

--- a/Freeform.Rigging/Rigging/View/Rigger.xaml
+++ b/Freeform.Rigging/Rigging/View/Rigger.xaml
@@ -156,6 +156,7 @@ If not, see <https://www.gnu.org/licenses/>.-->
                     </Button>
                     <TextBlock Style="{StaticResource HighlightTextBlock}"
                                Text="?"
+                               ToolTipService.InitialShowDelay="10"
                                FontSize="16"
                                HorizontalAlignment="Center"
                                VerticalAlignment="Center"


### PR DESCRIPTION
Fixed - Exporter was always checking P4 connections even if it was disabled in settings